### PR TITLE
Nelson777 patch update wwd 0.15

### DIFF
--- a/org.eclipse.Javascript.json
+++ b/org.eclipse.Javascript.json
@@ -41,7 +41,7 @@
     ],
     "sources" : [ {
       "type" : "archive",
-      "url" : "https://download.eclipse.org/wildwebdeveloper/releases/0.15/IDEs/eclipseide-wild-web-developer-0.14.0-linux.gtk.x86_64.tar.gz",
+      "url" : "https://download.eclipse.org/wildwebdeveloper/releases/0.15.0/IDEs/eclipseide-wild-web-developer-0.14.0-linux.gtk.x86_64.tar.gz",
       "sha512" : "1800af473a1041c477d7cdaf12f2c7074fe23de65a3a70e153f3ede3c1b570fb74a15da18bdd049479655cff643f9e1cc37c281d5daeca90c5b4d9f5d4e3587f",
       "strip-components" : 0
     },{

--- a/org.eclipse.Javascript.json
+++ b/org.eclipse.Javascript.json
@@ -41,7 +41,7 @@
     ],
     "sources" : [ {
       "type" : "archive",
-      "url" : "https://download.eclipse.org/wildwebdeveloper/releases/0.13.6/IDEs/eclipseide-wild-web-developer-0.14.0-linux.gtk.x86_64.tar.gz",
+      "url" : "https://download.eclipse.org/wildwebdeveloper/releases/0.15/IDEs/eclipseide-wild-web-developer-0.14.0-linux.gtk.x86_64.tar.gz",
       "sha512" : "1800af473a1041c477d7cdaf12f2c7074fe23de65a3a70e153f3ede3c1b570fb74a15da18bdd049479655cff643f9e1cc37c281d5daeca90c5b4d9f5d4e3587f",
       "strip-components" : 0
     },{

--- a/org.eclipse.Javascript.metainfo.xml
+++ b/org.eclipse.Javascript.metainfo.xml
@@ -31,6 +31,9 @@
   <developer_name>Eclipse Foundation</developer_name>
   <update_contact>mat.booth@redhat.com</update_contact>
   <releases>
+    <release version="0.15" date="2022-07-29">
+      <url>https://github.com/eclipse/wildwebdeveloper/blob/master/RELEASE_NOTES.md#015</url>
+    </release>
     <release version="0.13.6" date="2022-07-07">
       <url>https://github.com/eclipse/wildwebdeveloper/blob/master/RELEASE_NOTES.md#0136</url>
     </release>


### PR DESCRIPTION
As promised first PR on updates to WWD.

Although there's some things I do not understood well. I ask for your support so I can help better next time.

1. In this release WWD only updated a dependency. I didn't see anywhere where I can inform this. This is dealt automatically by Flathub ?
2. The new file has the exact same version. I checked with SHA512 and it's the exact same hash from previous version. If it's the same file does it change anything just updating the version ?
3. About flatpak-dev-shim-1.0.1-20211216.040236-6.so, I couldn't find any new version, so I left it as is. Is that it ?
4. I add the following code to org.eclipse.Javascript.metainfo.xml:
```
    <release version="0.15" date="2022-07-29">
      <url>https://github.com/eclipse/wildwebdeveloper/blob/master/RELEASE_NOTES.md#015</url>
    </release>
```
Is that it ? I can't open https://github.com/eclipse/wildwebdeveloper/blob/master/ nor https://github.com/eclipse/wildwebdeveloper/blob/master/RELEASE_NOTES.md#015

Thanks for your help and hoping I can help you further